### PR TITLE
Make sure nuget's libgit2sharp gets bundled correctly during release

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -2,5 +2,4 @@
 <packages>
   <package id="xunit.runners" version="1.9.2" />
   <package id="MSBuildTasks" version="1.4.0.45" />
-  <package id="LibGit2Sharp" version="0.21.0.176" targetFramework="net40" />
 </packages>

--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="xunit.runners" version="1.9.2" />
   <package id="MSBuildTasks" version="1.4.0.45" />
+  <package id="LibGit2Sharp" version="0.21.0.176" targetFramework="net40" />
 </packages>

--- a/ChocolateyTemplates/gittfs.nuspec
+++ b/ChocolateyTemplates/gittfs.nuspec
@@ -16,7 +16,7 @@ ${ReleaseNotesContents}
     <licenseUrl>https://github.com/git-tfs/git-tfs/blob/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <dependencies>
-      <dependency id="msysgit" />
+      <dependency id="git" />
     </dependencies>
   </metadata>
 </package>

--- a/README.md
+++ b/README.md
@@ -89,45 +89,45 @@ This is the complete list of commands in the master branch on github.
 
 ### Repository setup
 
-* [list-remote-branches](doc/commands/list-remote-branches.md) - since [0.17](../../releases/tag/v0.17.0)
-* [clone](doc/commands/clone.md) - since 0.9
-* [quick-clone](doc/commands/quick-clone.md) - since 0.9
-* [bootstrap](doc/commands/bootstrap.md) - since [0.11][v0.11]
-* [init](doc/commands/init.md) - since 0.9
+* [list-remote-branches](doc/commands/list-remote-branches.md): *list tfs branches that can be cloned or initialized* - since [0.17](../../releases/tag/v0.17.0)
+* [clone](doc/commands/clone.md): *clone a tfs path/branch and its history in a git repository* - since 0.9
+* [quick-clone](doc/commands/quick-clone.md): *clone a specific changeset of a tfs path/branch in a git repository* - since 0.9
+* [bootstrap](doc/commands/bootstrap.md): *bootstrap an existing git-tfs repository cloned from an existing repository* - since [0.11][v0.11]
+* [init](doc/commands/init.md): *initialize a git-tfs repository (without getting changesets)* - since 0.9
 
 ### Pull from TFS
 
-* [clone](doc/commands/clone.md) - since 0.9
-* [fetch](doc/commands/fetch.md) - since 0.9
-* [pull](doc/commands/pull.md) - since 0.9
-* [quick-clone](doc/commands/quick-clone.md) - since 0.9
-* [unshelve](doc/commands/unshelve.md) - since [0.11][v0.12]
-* [shelve-list](doc/commands/shelve-list.md) - since [0.12][v0.12]
-* [labels](doc/commands/labels.md) - since [0.17](../../releases/tag/v0.17.0)
+* [clone](doc/commands/clone.md): *clone a tfs path/branch and its history in a git repository* - since 0.9
+* [fetch](doc/commands/fetch.md): *get changesets from tfs and update the tfs remote* - since 0.9
+* [pull](doc/commands/pull.md): *get changesets from tfs, update the tfs remote and update your work* - since 0.9
+* [quick-clone](doc/commands/quick-clone.md): *clone a specific changeset (without history) of a tfs path/branch in a git repository* - since 0.9
+* [unshelve](doc/commands/unshelve.md): *fetch a tfs shelvesets in your repository* - since [0.11][v0.12]
+* [shelve-list](doc/commands/shelve-list.md): *list tfs shelvesets* - since [0.12][v0.12]
+* [labels](doc/commands/labels.md): *fetch tfs labels* - since [0.17](../../releases/tag/v0.17.0)
 
 ### Push to TFS
 
-* [rcheckin](doc/commands/rcheckin.md) - since [0.12][v0.12]
-* [checkin](doc/commands/checkin.md) - since 0.10
-* [checkintool](doc/commands/checkintool.md) - since 0.10
-* [shelve](doc/commands/shelve.md) - since 0.9
+* [rcheckin](doc/commands/rcheckin.md): *replicate your git commits as tfs changesets* - since [0.12][v0.12]
+* [checkin](doc/commands/checkin.md): *checkin your git commits as one tfs changeset* - since 0.10
+* [checkintool](doc/commands/checkintool.md): *checkin in tfs using the tfs checkin dialog* - since 0.10
+* [shelve](doc/commands/shelve.md): *create a shelveset from git commits* - since 0.9
 
 ### Manage TFS branches
 
-* [list-remote-branches](doc/commands/list-remote-branches.md) - since [0.17](../../releases/tag/v0.17.0)
-* [branch](doc/commands/branch.md) - since [0.17](../../releases/tag/v0.17.0)
+* [list-remote-branches](doc/commands/list-remote-branches.md): *list tfs branches that can be cloned or initialized* - since [0.17](../../releases/tag/v0.17.0)
+* [branch](doc/commands/branch.md): *manage (initialize, create, remove) tfs branches* - since [0.17](../../releases/tag/v0.17.0)
 
 ### Other
 
-* [info](doc/commands/info.md)
-* [cleanup](doc/commands/cleanup.md) - since 0.10
-* [cleanup-workspaces](doc/commands/cleanup-workspaces.md) - since 0.10
-* [help](doc/commands/help.md) - since 0.9
-* [verify](doc/commands/verify.md) - since [0.11][v0.11]
+* [info](doc/commands/info.md): *get some informations about git-tfs and tfs*
+* [cleanup](doc/commands/cleanup.md): *clean some git-tfs internal objects* - since 0.10
+* [cleanup-workspaces](doc/commands/cleanup-workspaces.md): *clean tfs workspaces created by git-tfs* - since 0.10
+* [help](doc/commands/help.md): *get help on git-tfs commands* - since 0.9
+* [verify](doc/commands/verify.md): *verify the changesets fetched* - since [0.11][v0.11]
 * [autotag](doc/config.md#per-tfs-remote) option - since [0.12][v0.12]
-* [subtree](doc/commands/subtree.md) - since [0.19](../../releases/tag/v0.19.0)
-* [reset-remote](doc/commands/reset-remote.md) - since [0.19](../../releases/tag/v0.19.0)
-* [checkout](doc/commands/checkout.md) - since [0.21](../../releases/tag/v0.21.0)
+* [subtree](doc/commands/subtree.md): *manage sparse tfs pathes with git-tfs* - since [0.19](../../releases/tag/v0.19.0)
+* [reset-remote](doc/commands/reset-remote.md): *reset a tfs remote to a previous changeset to fecth again its history* - since [0.19](../../releases/tag/v0.19.0)
+* [checkout](doc/commands/checkout.md): *checkout a commit by a changeset id* - since [0.21](../../releases/tag/v0.21.0)
 * diagnostics (for git-tfs developpers only) - since 0.9
 
 * [config file](doc/config.md)

--- a/Release.proj
+++ b/Release.proj
@@ -124,6 +124,8 @@
   <!-- Internal: Called by release to compile git-tfs.exe -->
   <Target Name="Build">
     <MSBuild Projects="GitTfs.sln" Targets="Rebuild" Properties="Configuration=Release;Platform=$(TargetPlatform);WarningLevel=0" />
+    <!-- Build a second time to ensure that the libgit2 NativeBinaries get copied. -->
+    <MSBuild Projects="GitTfs.sln" Targets="Rebuild" Properties="Configuration=Release;Platform=$(TargetPlatform);WarningLevel=0" />
   </Target>
 
   <!-- Internal: Called by Release to tag the git-tfs repository. -->

--- a/Release.proj
+++ b/Release.proj
@@ -140,7 +140,6 @@
 
   <!-- Internal: Called by Release to create the zip. -->
   <Target Name="Package" DependsOnTargets="VersionRequired; MSBuildCommunityTasks; DefineReleaseFiles">
-    <Message Text="@(ReleaseFiles)" />
     <Zip Files="@(ReleaseFiles)" ZipFileName="$(Archive)" WorkingDirectory="$(BuildDir)" />
   </Target>
 

--- a/Release.proj
+++ b/Release.proj
@@ -14,6 +14,9 @@
     <!-- Where git-tfs.exe and its dependencies are built. -->
     <BuildDir>$(SolutionDir)/GitTfs/bin/Release</BuildDir>
 
+    <!-- Where libgit2sharp's native DLLs are. -->
+    <LibGit2SharpDir>$(SolutionDir)/packages/LibGit2Sharp.0.21.0.176/lib/net40</LibGit2SharpDir>
+
     <!-- The name of the output zip file. -->
     <PackagedDir>$(SolutionDir)/Releases</PackagedDir>
     <PackageFile>GitTfs-$(Version).zip</PackageFile>
@@ -60,7 +63,7 @@
       <ReleaseFiles Include="$(BuildDir)\git-tfs.exe" />
       <ReleaseFiles Include="$(BuildDir)\*.config" />
       <ReleaseFiles Include="$(BuildDir)\*.dll" Exclude="$(BuildDir)\Microsoft.*.dll" />
-      <ReleaseFiles Include="$(BuildDir)\NativeBinaries\**\*.dll" />
+      <ReleaseFiles Include="$(LibGit2SharpDir)\NativeBinaries\**\*.dll" />
     </ItemGroup>
   </Target>
 

--- a/Release.proj
+++ b/Release.proj
@@ -114,7 +114,7 @@
   </Target>
 
   <!-- Internal. -->
-  <Target Name="UpdateVersionInReadme" DependsOnTargets="VersionRequired">
+  <Target Name="UpdateVersionInReadme" DependsOnTargets="VersionRequired; MSBuildCommunityTasks">
     <FileUpdate Files="README.md" Regex="The most recent version is __.*__\." ReplacementText="The most recent version is __$(Version)__." />
   </Target>
 

--- a/Release.proj
+++ b/Release.proj
@@ -34,6 +34,8 @@
     <WebSiteDir>$(PackagedDir)/git-tfs.github.com</WebSiteDir>
     <DownloadButton>_includes/download_button.html</DownloadButton>
     <WebSiteRepository>https://github.com/$(GitHubOwner)/git-tfs.github.com.git</WebSiteRepository>
+
+    <DryRun Condition="'$(DryRun)' == ''">True</DryRun>
   </PropertyGroup>
 
   <!-- Internal. -->
@@ -129,8 +131,8 @@
   <!-- Internal: Called by Release to push the release tag to github.com -->
   <Target Name="PushSource" DependsOnTargets="VersionRequired">
     <!-- Do these separately so that the push to master blocks the push of the tag. -->
-    <Exec Command="git push $(OriginUrl) HEAD:refs/heads/master" />
-    <Exec Command="git push $(OriginUrl) v$(Version)" />
+    <Exec Condition="'$(DryRun)' == 'False'" Command="git push $(OriginUrl) HEAD:refs/heads/master" />
+    <Exec Condition="'$(DryRun)' == 'False'" Command="git push $(OriginUrl) v$(Version)" />
   </Target>
 
   <!-- Internal: Called by Release to create the zip. -->
@@ -140,7 +142,7 @@
 
   <!-- Internal: Create a release on github.com -->
   <Target Name="ReleaseOnGitHub" DependsOnTargets="VersionRequired; AuthTokenRequired; MSBuildCommunityTasks">
-    <CreateRelease Repository="$(GitHubOwner)/$(GitHubRepository)" TagName="v$(Version)" Files="@(ArchiveFile)" OauthToken="$(GitHubAuthToken)" ReleaseNotesFile="$(ReleaseNotes)" />
+    <CreateRelease Condition="'$(DryRun)' == 'False'" Repository="$(GitHubOwner)/$(GitHubRepository)" TagName="v$(Version)" Files="@(ArchiveFile)" OauthToken="$(GitHubAuthToken)" ReleaseNotesFile="$(ReleaseNotes)" />
   </Target>
 
   <!-- Internal: Update the "download" button on git-tfs.com -->
@@ -150,7 +152,7 @@
     <WriteLinesToFile File="$(WebSiteDir)/$(DownloadButton)" Lines="&lt;a href=%22$(DownloadUrl)%22 class=%22download-button%22&gt;Download v$(Version)&lt;/a&gt;" Overwrite="true" Encoding="ASCII"/>
     <!-- If the previous attempt was aborted, we might have already updated the button and this commit will be empty. -->
     <Exec WorkingDirectory="$(WebSiteDir)" Command="git commit -m %22v$(Version)%22 $(DownloadButton)" IgnoreExitCode="true" />
-    <Exec WorkingDirectory="$(WebSiteDir)" Command="git push $(WebSiteRepository) HEAD:refs/heads/master" />
+    <Exec Condition="'$(DryRun)' == 'False'" WorkingDirectory="$(WebSiteDir)" Command="git push $(WebSiteRepository) HEAD:refs/heads/master" />
   </Target>
 
   <!-- Internal. -->
@@ -230,6 +232,6 @@
 
   <!-- Internal. -->
   <Target Name="PushChocolateyPackage" DependsOnTargets="BuildChocolateyPackage">
-    <Exec Command="cpush $(ChocolateyNupkg)" />
+    <Exec Condition="'$(DryRun)' == 'False'" Command="cpush $(ChocolateyNupkg)" />
   </Target>
 </Project>

--- a/Release.proj
+++ b/Release.proj
@@ -133,6 +133,7 @@
     <!-- Do these separately so that the push to master blocks the push of the tag. -->
     <Exec Condition="'$(DryRun)' == 'False'" Command="git push $(OriginUrl) HEAD:refs/heads/master" />
     <Exec Condition="'$(DryRun)' == 'False'" Command="git push $(OriginUrl) v$(Version)" />
+    <Message Condition="'$(DryRun)' != 'False'" Text="(would push to github.com)" />
   </Target>
 
   <!-- Internal: Called by Release to create the zip. -->
@@ -143,6 +144,7 @@
   <!-- Internal: Create a release on github.com -->
   <Target Name="ReleaseOnGitHub" DependsOnTargets="VersionRequired; AuthTokenRequired; MSBuildCommunityTasks">
     <CreateRelease Condition="'$(DryRun)' == 'False'" Repository="$(GitHubOwner)/$(GitHubRepository)" TagName="v$(Version)" Files="@(ArchiveFile)" OauthToken="$(GitHubAuthToken)" ReleaseNotesFile="$(ReleaseNotes)" />
+    <Message Condition="'$(DryRun)' != 'False'" Text="(would create release on github.com)" />
   </Target>
 
   <!-- Internal: Update the "download" button on git-tfs.com -->
@@ -153,6 +155,7 @@
     <!-- If the previous attempt was aborted, we might have already updated the button and this commit will be empty. -->
     <Exec WorkingDirectory="$(WebSiteDir)" Command="git commit -m %22v$(Version)%22 $(DownloadButton)" IgnoreExitCode="true" />
     <Exec Condition="'$(DryRun)' == 'False'" WorkingDirectory="$(WebSiteDir)" Command="git push $(WebSiteRepository) HEAD:refs/heads/master" />
+    <Message Condition="'$(DryRun)' != 'False'" Text="(would push pages site to github.com)" />
   </Target>
 
   <!-- Internal. -->
@@ -233,5 +236,6 @@
   <!-- Internal. -->
   <Target Name="PushChocolateyPackage" DependsOnTargets="BuildChocolateyPackage">
     <Exec Condition="'$(DryRun)' == 'False'" Command="cpush $(ChocolateyNupkg)" />
+    <Message Condition="'$(DryRun)' != 'False'" Text="(would push chocolatey package)" />
   </Target>
 </Project>

--- a/Release.proj
+++ b/Release.proj
@@ -14,9 +14,6 @@
     <!-- Where git-tfs.exe and its dependencies are built. -->
     <BuildDir>$(SolutionDir)/GitTfs/bin/Release</BuildDir>
 
-    <!-- Where libgit2sharp's native DLLs are. -->
-    <LibGit2SharpDir>$(SolutionDir)/packages/LibGit2Sharp.0.21.0.176/lib/net40</LibGit2SharpDir>
-
     <!-- The name of the output zip file. -->
     <PackagedDir>$(SolutionDir)/Releases</PackagedDir>
     <PackageFile>GitTfs-$(Version).zip</PackageFile>
@@ -63,7 +60,7 @@
       <ReleaseFiles Include="$(BuildDir)\git-tfs.exe" />
       <ReleaseFiles Include="$(BuildDir)\*.config" />
       <ReleaseFiles Include="$(BuildDir)\*.dll" Exclude="$(BuildDir)\Microsoft.*.dll" />
-      <ReleaseFiles Include="$(LibGit2SharpDir)\NativeBinaries\**\*.dll" />
+      <ReleaseFiles Include="$(BuildDir)\NativeBinaries\**\*.dll" />
     </ItemGroup>
   </Target>
 

--- a/Release.proj
+++ b/Release.proj
@@ -71,15 +71,18 @@
     </ArchiveFile>
   </ItemGroup>
 
-  <!-- Load nuget, so we can get dependencies. (Dependencies are not checked in to git.) -->
+  <!-- Use nuget get dependencies. (Dependencies are not checked in to git.) -->
   <PropertyGroup>
-    <PackagesConfig>$(SolutionDir)/.nuget/packages.config</PackagesConfig>
-    <RequireRestoreConsent>false</RequireRestoreConsent>
-    <MSBuildCommunityTasksPath>$(SolutionDir)/packages/MSBuildTasks.1.4.0.45/tools</MSBuildCommunityTasksPath>
+    <NugetExe>$(SolutionDir)\.nuget\nuget.exe</NugetExe>
+    <NugetPackagesDir>$(SolutionDir)/packages</NugetPackagesDir>
+    <MSBuildCommunityTasksPath>$(NugetPackagesDir)/MSBuildTasks.1.4.0.45/tools</MSBuildCommunityTasksPath>
     <MSBuildCommunityTasksLib>$(MSBuildCommunityTasksPath)/MSBuild.Community.Tasks.dll</MSBuildCommunityTasksLib>
     <MSBuildGitTfsTasksLib>$(SolutionDir)/packages/MSBuildGitTfsTasks/GitTfsTasks.dll</MSBuildGitTfsTasksLib>
   </PropertyGroup>
-  <Import Project="$(SolutionDir)/.nuget/nuget.targets" />
+  <Target Name="RestorePackages">
+    <Exec Command="$(NugetExe) restore -PackagesDirectory $(NugetPackagesDir) $(SolutionDir)/.nuget/packages.config" />
+    <Exec Command="$(NugetExe) restore -PackagesDirectory $(NugetPackagesDir) $(SolutionDir)/GitTfs/packages.config" />
+  </Target>
 
   <!-- Load some extra tasks. -->
   <Target Name="MSBuildCommunityTasks" DependsOnTargets="RestorePackages" />

--- a/Release.proj
+++ b/Release.proj
@@ -52,15 +52,17 @@
   </Target>
 
   <!-- The contents of the zip. -->
-  <ItemGroup>
-    <ReleaseFiles Include="$(SolutionDir)\README.md" />
-    <ReleaseFiles Include="$(SolutionDir)\LICENSE" />
-    <ReleaseFiles Include="$(SolutionDir)\NOTICE" />
-    <ReleaseFiles Include="$(BuildDir)\git-tfs.exe" />
-    <ReleaseFiles Include="$(BuildDir)\*.config" />
-    <ReleaseFiles Include="$(BuildDir)\*.dll" Exclude="$(BuildDir)\Microsoft.*.dll" />
-    <ReleaseFiles Include="$(BuildDir)\NativeBinaries\**\*.dll" />
-  </ItemGroup>
+  <Target Name="DefineReleaseFiles">
+    <ItemGroup>
+      <ReleaseFiles Include="$(SolutionDir)\README.md" />
+      <ReleaseFiles Include="$(SolutionDir)\LICENSE" />
+      <ReleaseFiles Include="$(SolutionDir)\NOTICE" />
+      <ReleaseFiles Include="$(BuildDir)\git-tfs.exe" />
+      <ReleaseFiles Include="$(BuildDir)\*.config" />
+      <ReleaseFiles Include="$(BuildDir)\*.dll" Exclude="$(BuildDir)\Microsoft.*.dll" />
+      <ReleaseFiles Include="$(BuildDir)\NativeBinaries\**\*.dll" />
+    </ItemGroup>
+  </Target>
 
   <!-- The zip. -->
   <ItemGroup>
@@ -137,7 +139,8 @@
   </Target>
 
   <!-- Internal: Called by Release to create the zip. -->
-  <Target Name="Package" DependsOnTargets="VersionRequired; MSBuildCommunityTasks">
+  <Target Name="Package" DependsOnTargets="VersionRequired; MSBuildCommunityTasks; DefineReleaseFiles">
+    <Message Text="@(ReleaseFiles)" />
     <Zip Files="@(ReleaseFiles)" ZipFileName="$(Archive)" WorkingDirectory="$(BuildDir)" />
   </Target>
 

--- a/Release.proj
+++ b/Release.proj
@@ -123,9 +123,8 @@
 
   <!-- Internal: Called by release to compile git-tfs.exe -->
   <Target Name="Build">
-    <MSBuild Projects="GitTfs.sln" Targets="Rebuild" Properties="Configuration=Release;Platform=$(TargetPlatform);WarningLevel=0" />
-    <!-- Build a second time to ensure that the libgit2 NativeBinaries get copied. -->
-    <MSBuild Projects="GitTfs.sln" Targets="Rebuild" Properties="Configuration=Release;Platform=$(TargetPlatform);WarningLevel=0" />
+    <!-- Build by shelling out to ensure that the libgit2 NativeBinaries get copied. -->
+    <Exec Command="msbuild GitTfs.sln /t:Rebuild &quot;/p:Configuration=Release;Platform=$(TargetPlatform);WarningLevel=0&quot;" />
   </Target>
 
   <!-- Internal: Called by Release to tag the git-tfs repository. -->

--- a/Release.proj
+++ b/Release.proj
@@ -107,7 +107,8 @@
   <!-- Internal: Called by Release to set the new version. -->
   <Target Name="UpdateVersion" DependsOnTargets="UpdateAssemblyVersionAttribute; UpdateVersionInReadme">
     <!-- This is OK to fail. If a previous release attempt failed, the commit will now be empty. -->
-    <Exec Command="git commit -m v$(Version) $(VersionFilePath) README.md" IgnoreExitCode="true" />
+    <Exec Condition="'$(DryRun)' == 'False'" Command="git commit -m v$(Version) $(VersionFilePath) README.md" IgnoreExitCode="true" />
+    <Message Condition="'$(DryRun)' != 'False'" Text="(would git commit -m v$(Version) $(VersionFilePath) README.md)" />
   </Target>
 
   <!-- Internal. -->

--- a/Release.proj
+++ b/Release.proj
@@ -48,7 +48,7 @@
 
   <!-- Internal. -->
   <Target Name="AuthTokenRequired">
-    <Error Text="You must set a github.com auth token in auth.targets (see auth.targets.example)" Condition="'$(GitHubAuthToken)' == ''" />
+    <Error Text="You must set a github.com auth token in auth.targets (see auth.targets.example)" Condition="'$(DryRun)' == 'False' And '$(GitHubAuthToken)' == ''" />
   </Target>
 
   <!-- The contents of the zip. -->

--- a/Release.proj
+++ b/Release.proj
@@ -123,8 +123,7 @@
 
   <!-- Internal: Called by release to compile git-tfs.exe -->
   <Target Name="Build">
-    <!-- Build by shelling out to ensure that the libgit2 NativeBinaries get copied. -->
-    <Exec Command="msbuild GitTfs.sln /t:Rebuild &quot;/p:Configuration=Release;Platform=$(TargetPlatform);WarningLevel=0&quot;" />
+    <MSBuild Projects="GitTfs.sln" Targets="Rebuild" Properties="Configuration=Release;Platform=$(TargetPlatform);WarningLevel=0" />
   </Target>
 
   <!-- Internal: Called by Release to tag the git-tfs repository. -->

--- a/Releasing.md
+++ b/Releasing.md
@@ -13,8 +13,14 @@ Normally, you should do this:
 
 2. Set the auth.targets file with with your OAuth token (see auth.targets.example)
 
-3. Build the release and include the version (e.g. X.Y.Z) and the name of a changelog file (optional).
+3. Do a dry run of the release. Include the version (e.g. X.Y.Z) and the name of a changelog file (optional).
 
 ```
 > msbuild Release.proj /t:Release /p:Version=X.Y.Z
+```
+
+4. Build the release. Include the version (e.g. X.Y.Z) and the name of a changelog file (optional).
+
+```
+> msbuild Release.proj /t:Release /p:Version=X.Y.Z;DryRun=False
 ```

--- a/Releasing.md
+++ b/Releasing.md
@@ -11,15 +11,21 @@ Normally, you should do this:
 > git status
 ```
 
-2. Set the auth.targets file with with your OAuth token (see auth.targets.example)
+2. Restore submodules
 
-3. Do a dry run of the release. Include the version (e.g. X.Y.Z) and the name of a changelog file (optional).
+```
+> git submodule update --init --recursive
+```
+
+3. Set the auth.targets file with with your OAuth token (see auth.targets.example)
+
+4. Do a dry run of the release. Include the version (e.g. X.Y.Z) and the name of a changelog file (optional).
 
 ```
 > msbuild Release.proj /t:Release /p:Version=X.Y.Z
 ```
 
-4. Build the release. Include the version (e.g. X.Y.Z) and the name of a changelog file (optional).
+5. Build the release. Include the version (e.g. X.Y.Z) and the name of a changelog file (optional).
 
 ```
 > msbuild Release.proj /t:Release /p:Version=X.Y.Z;DryRun=False


### PR DESCRIPTION
This branch merges master into git-tfs/git-tfs#757 (so that I could use git-tfs/git-tfs#779), and it gets `git2*.dll` back into the archive produced by `Release.proj`.

```
Package:
  Creating zip file "./Releases/GitTfs-0.0.0.zip".
    added "README.md".
    added "LICENSE".
    added "NOTICE".
    added "git-tfs.exe".
    added "git-tfs.exe.config".
    added "GitTfs.Vs2010.dll".
    added "GitTfs.Vs2012.dll".
    added "GitTfs.Vs2013.dll".
    added "GitTfs.VsFake.dll".
    added "LibGit2Sharp.dll".
    added "NDesk.Options.dll".
    added "StructureMap.dll".
    added "System.Net.Http.Formatting.dll".
    added "System.Web.Http.dll".
    added "NativeBinaries/amd64/git2-e0902fb.dll".
    added "NativeBinaries/x86/git2-e0902fb.dll".
  Created zip file "./Releases/GitTfs-0.0.0.zip" successfully.
```

The interesting part of this branch (in other words, excluding the merge of master) is in [this diff](https://github.com/git-tfs/git-tfs/compare/a83f1d0...e4be9b0).

cc @pmiossec @allansson 
